### PR TITLE
Fix: vim.highlight.create is deprecated in favour of nvim_set_hl

### DIFF
--- a/lua/perfanno/util.lua
+++ b/lua/perfanno/util.lua
@@ -96,14 +96,14 @@ local num_highlights = 0
 
 function M.make_fg_highlight(color)
     num_highlights = num_highlights + 1
-    vim.highlight.create("PerfAnno" .. num_highlights, {guifg = color})
+    vim.api.nvim_set_hl(0, "PerfAnno" .. num_highlights, {fg = color})
 
     return "PerfAnno" .. num_highlights
 end
 
 function M.make_bg_highlight(color)
     num_highlights = num_highlights + 1
-    vim.highlight.create("PerfAnno" .. num_highlights, {guibg = color})
+    vim.api.nvim_set_hl(0, "PerfAnno" .. num_highlights, {bg = color})
 
     return "PerfAnno" .. num_highlights
 end


### PR DESCRIPTION
Hi, thanks for the plugin, really amazing how nicely it works.

This PR removes the deprecation warning you get in latest Neovim. I'm not sure what is the minimal version for nvim_set_hl, but it's [available on latest stable](https://neovim.io/doc/user/api.html#nvim_set_hl()).