### PR TITLE
Lua profile dump/load

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,11 @@ Simply use the following commands in order:
 * `:PerfLuaProfileStop` stops the current profiling run and loads the stack traces into the call
   graph. Automatically annotates all buffers if `annotate_after_load` is set.
 
+Results can be saved on disk and loaded later using:
+
+* `:PerfLuaProfileDump <filename>` stores current LuaJIT profiling results to a JSON file
+* `:PerfLuaProfileLoad <filename>` loads LuaJIT profiling results from a JSON file
+
 ### Control how annotations are displayed
 
 * `:PerfPickEvent` chooses a different event from the perf data to display. For example, you could use this to switch between cpu cycles, branch mispredictions, and cache misses.

--- a/lua/perfanno/init.lua
+++ b/lua/perfanno/init.lua
@@ -20,6 +20,8 @@ function M.setup(opts)
     -- Lua profiling via the internal LuaJit profiler
     cmd('PerfLuaProfileStart', M.lua_profile_start, {})
     cmd('PerfLuaProfileStop', M.lua_profile_stop, {})
+    cmd('PerfLuaProfileDump', M.lua_profile_dump, { nargs = 1 })
+    cmd('PerfLuaProfileLoad', M.lua_profile_load, { nargs = 1 })
 
     -- Commands that control what and how to annotate.
     cmd('PerfPickEvent', M.pick_event, {})
@@ -141,6 +143,20 @@ function M.lua_profile_stop()
     require("perfanno.lua_profile").stop()
     local callgraph = require("perfanno.callgraph")
 
+    if callgraph.is_loaded() and config.values.annotate_after_load then
+        M.annotate()
+    end
+end
+
+--- Dumps current LuaJIT profiling results to a file
+function M.lua_profile_dump(opts)
+    require("perfanno.lua_profile").dump(opts.args[1])
+end
+
+--- Loads LuaJIT profiling results from a file
+function M.lua_profile_load(opts)
+    require("perfanno.lua_profile").load(opts.args[1])
+    local callgraph = require("perfanno.callgraph")
     if callgraph.is_loaded() and config.values.annotate_after_load then
         M.annotate()
     end


### PR DESCRIPTION
It is sometimes handy to store profiling results for later. This PR adds commands that allow to store the LuaJIT profiling results as a simple JSON file.