### PR TITLE
Add callback to manually determine the path to the perf data file

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,11 @@ require("perfanno").setup {
         -- weirdlang = {
         --     "weirdfunc",
         -- }
-    }
+    },
+
+    -- Overwrite the default behaviour of prompting for the path to the perf.data with a custom function that returns
+    -- the path to a perf file as string.
+    get_path_callback = nil,
 }
 
 local telescope = require("telescope")

--- a/lua/perfanno/config.lua
+++ b/lua/perfanno/config.lua
@@ -41,6 +41,10 @@ local defaults = {
         --     "weirdfunc",
         -- }
     },
+
+    -- Overwrite the default behaviour of prompting for the path to the perf.data with a custom function that returns
+    -- the path to a perf file as string.
+    get_path_callback = nil,
 }
 
 local M = {}

--- a/lua/perfanno/init.lua
+++ b/lua/perfanno/init.lua
@@ -60,7 +60,9 @@ end
 -- @param default Default file such as "perf.data" to look for.
 -- @return Data file
 local function get_data_file(default)
-    if vim.fn.filereadable(default) == 1 then
+    if config.values.get_path_callback ~= nil and type(config.values.get_path_callback) == "function" then
+        return config.values.get_path_callback()
+    elseif vim.fn.filereadable(default) == 1 then
         return default
     else
         local co = coroutine.running()


### PR DESCRIPTION
Since I can determine the path to my perf file programmatically  I don't want to pass the path to `PerfLoadCallGraph` each time. 
I decided to use a callback since args passed to the coroutine couldn't be changed after it's started.

What do you think?