### PR TITLE
refactor!: remove nvim-treesitter dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ https://user-images.githubusercontent.com/15610942/153775719-ed236a8d-d012-448d-
 
 ## Installation
 
-This plugin requires NeoVim 0.7 and was tested with perf 5.16.
+This plugin requires NeoVim 0.9 and was tested with perf 5.16.
 The call graph mode may require a relatively recent version of perf that supports folded output, though it should be easy to add support for older versions manually.
 
 You should be able to install this plugin the same way you install other NeoVim lua plugins, e.g. via `use "t-troebst/perfanno.nvim"` in packer.

--- a/doc/perfanno.txt
+++ b/doc/perfanno.txt
@@ -44,7 +44,7 @@ to the hottest callers of any piece of code or any function. See
 ==============================================================================
 INSTALLATION                                             *perfanno-installation*
 
-This plugin requires NeoVim 0.7 and was tested with perf 5.16.
+This plugin requires NeoVim 0.9 and was tested with perf 5.16.
 If you wish to load a call graph with stack traces, you may need a relatively
 recent version of perf.
 
@@ -63,9 +63,6 @@ Dependencies~
 If you want to use the commands that jump to the hottest lines of code, you
 will probably want to have `telescope.nvim` installed, otherwise the plugin
 will fall back to |vim.ui.select|.
-
-If you want to use |:PerfAnnotateFunction| or |:PerfHottestCallersFunction|
-then you will also need `nvim-treesitter`.
 
 ==============================================================================
 CONFIGURATION                                                  *perfanno-config*

--- a/lua/perfanno/treesitter.lua
+++ b/lua/perfanno/treesitter.lua
@@ -2,57 +2,62 @@
 
 local config = require("perfanno.config")
 
-local ok1, ts_utils = pcall(require, "nvim-treesitter.ts_utils")
-local ok2, parsers = pcall(require, "nvim-treesitter.parsers")
-
-if not (ok1 and ok2) then
-    return
-end
-
 local M = {}
 
---- Gets treesitter node at a specific position in a buffer.
--- @param bufnr Buffer number of the buffer.
--- @param linenr Line number (1-indexed).
--- @param column Column number (0-indexed).
--- @return Either treesitter node at that positino or nil if impossible.
-local function get_node_at_line(bufnr, linenr, column)
-    local root_tree = parsers.get_parser(bufnr)
+-- Gets treesitter node at a specific position in a buffer.
+---@param bufnr number of the buffer.
+---@param line number (1-indexed).
+---@param column number (0-indexed).
+---@return TSNode?
+local function get_node_at_line(bufnr, line, column)
+    local root_tree =
+        vim.treesitter.get_parser(bufnr, vim.treesitter.language.get_lang(vim.bo[bufnr].filetype))
 
     if not root_tree then
         return nil
     end
 
-    local root = ts_utils.get_root_for_position(linenr - 1, column, root_tree)
+    local lang_tree = root_tree:language_for_range { line - 1, column, line - 1, column }
+
+    ---@type TSNode?
+    local root
+    for _, tree in pairs(lang_tree:trees()) do
+        root = tree:root()
+
+        if root and vim.treesitter.is_in_node_range(root, line - 1, column) then
+            break
+        end
+    end
 
     if not root then
         return nil
     end
 
-    return root:named_descendant_for_range(linenr - 1, column, linenr - 1, column)
+    return root:named_descendant_for_range(line - 1, column, line - 1, column)
 end
 
 --- Gets lines of the smalled node surrounding given position whose type matches a pattern.
--- @param bufnr Buffer number of the buffer, current if nil.
--- @param linenr Line number (1-indexed).
--- @param column Column number (0-indexed).
--- @param type_patterns List of lua patterns to apply to node types.
--- @return start line, end line (1-indexed, inclusive) of first parent node that matches a pattern.
+---@param bufnr number of the buffer, current if nil.
+---@param linenr number (1-indexed).
+---@param column number (0-indexed).
+---@param type_patterns string[] List of lua patterns to apply to node types.
+---@return integer?, integer? - start line, end line (1-indexed, inclusive) of first parent node that matches a pattern.
 --         If no matching node was found, return nil.
 function M.get_context_lines(bufnr, linenr, column, type_patterns)
     bufnr = bufnr or vim.api.nvim_get_current_buf()
-    local lang = parsers.get_buf_lang(bufnr)
-
-    if not parsers.has_parser(lang) then
-        return nil
-    end
 
     local node = get_node_at_line(bufnr, linenr, column)
 
     while node do
         for _, pattern in ipairs(type_patterns) do
             if node:type():match(pattern) then
-                local srow, _, erow, _ = ts_utils.get_vim_range({ node:range() }, bufnr)
+                local srow, _, erow, ecol = node:range()
+                srow = srow + 1
+                erow = erow + 1
+
+                if ecol == 0 then
+                    erow = erow - 1
+                end
 
                 return srow, erow
             end
@@ -64,22 +69,24 @@ end
 --- Get lines of the function that surrounds a given position.
 -- This function uses the patterns specified in the ts_function_patterns value
 -- of the config to detect functions.
--- @param bufnr Buffer number to use, current if nil.
--- @param linenr Line number (1-indexed), current if nil.
--- @param column Column number (0-indexed), current if linenr is nil and 0 if column is nil.
--- @return start line, end line (1-indexed, inclusive) of surrounding function, or nil if none was
+---@param bufnr number to use, current if nil.
+---@param linenr number (1-indexed), current if nil.
+---@param column number (0-indexed), current if linenr is nil and 0 if column is nil.
+---@return integer?, integer? - start line, end line (1-indexed, inclusive) of surrounding function, or nil if none was
 --         found.
 function M.get_function_lines(bufnr, linenr, column)
     bufnr = bufnr or vim.api.nvim_get_current_buf()
-    local lang = parsers.get_buf_lang(bufnr)
+
+    local lang = vim.treesitter.language.get_lang(vim.bo[bufnr].filetype)
 
     if not linenr then
+        ---@type number, number
         linenr, column = unpack(vim.api.nvim_win_get_cursor(0))
     else
         column = column or 0
     end
 
-    if not parsers.has_parser(lang) then
+    if vim.treesitter.highlighter.active[bufnr] == nil then
         return nil
     end
 


### PR DESCRIPTION
The module/plugin aspect of nvim-treesitter is deprecated and will be removed in the 1.0 rewrite - so this just removes that dependency to avoid any issues in the future and instead relies on the built-in treesitter api in neovim. This does raise the neovim requirement to 0.9 though.