### PR TITLE
Add basic multi-thread support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,3 +85,34 @@ Custom profilers integrate via:
 ```lua
 require("perfanno").load_traces({ event_name = {{ count = N, frames = {...} }, ...} })
 ```
+
+## Per-Thread Profiling Support
+
+The plugin supports profiling multi-threaded applications with per-thread analysis.
+
+### Configuration
+
+Enable thread support in your setup:
+```lua
+require("perfanno").setup({
+    thread_support = true,  -- Disabled by default for backward compatibility
+})
+```
+
+### Usage
+
+When `thread_support` is enabled:
+1. Run `:PerfLoadCallGraph` or `:PerfLoadFlat` with a multi-threaded perf.data
+2. Plugin automatically detects threads using `perf script -F tid,comm`
+3. If multiple threads found, shows picker with options:
+   - "All threads (aggregated)" - default behavior, combines all threads
+   - Individual threads: "TID 49581 (unit_tests)", "TID 49584 (cuda-EvtHandlr)", etc.
+4. Select desired thread(s) to profile
+
+### Implementation Details
+
+- Thread detection: Uses `perf script -i perf.data -F tid,comm | head -10000`
+- Thread filtering: Passes `--tid=XXX` to `perf report` for selected thread
+- Single-threaded perf.data: No picker shown, behaves as normal
+- Disabled by default: When `thread_support = false`, always aggregates all threads (backward compatible)
+- Scalability: Uses `perf report` (pre-aggregated) instead of `perf script` (raw samples) for efficiency

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,7 +111,7 @@ When `thread_support` is enabled:
 
 ### Implementation Details
 
-- Thread detection: Uses `perf script -i perf.data -F tid,comm | head -10000`
+- Thread detection: Uses `perf report -F pid,comm --no-children -g none` for fast, complete thread list
 - Thread filtering: Passes `--tid=XXX` to `perf report` for selected thread
 - Single-threaded perf.data: No picker shown, behaves as normal
 - Disabled by default: When `thread_support = false`, always aggregates all threads (backward compatible)

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ https://user-images.githubusercontent.com/15610942/153775719-ed236a8d-d012-448d-
 
 ## Installation
 
-This plugin requires NeoVim 0.9 and was tested most recently with NeoVim 0.11 and perf 5.16.
+This plugin requires NeoVim 0.10 and was tested most recently with NeoVim 0.11 and perf 5.16.
 The call graph mode may require a relatively recent version of perf that supports folded output, though it should be easy to add support for older versions manually.
 
 You should be able to install this plugin the same way you install other NeoVim lua plugins, e.g. via `use "t-troebst/perfanno.nvim"` in packer.
@@ -123,6 +123,10 @@ require("perfanno").setup {
     -- Overwrite the default behaviour of prompting for the path to the perf.data with a custom function that returns
     -- the path to a perf file as string.
     get_path_callback = nil,
+
+    -- Enable per-thread profiling support for multi-threaded applications
+    -- When enabled, you can select which thread(s) to profile when loading perf.data
+    thread_support = false,
 }
 
 local telescope = require("telescope")
@@ -166,6 +170,24 @@ If the `dwarf` option creates files that are too large or take too long to proce
 
 However, this requires that your program and all libraries have been compiled with `-fno-omit-frame-pointer` and you may find that the line numbers are slightly off.
 For more information, see the documentation of perf.
+
+### Multi-threaded Applications
+
+If you're profiling multi-threaded applications and want to analyze per-thread performance, enable thread support in your configuration:
+
+```lua
+require("perfanno").setup({
+    thread_support = true,
+})
+```
+
+When loading perf data from a multi-threaded program, you'll be prompted to select which thread(s) to profile:
+- **All threads (aggregated)** - Default behavior, combines samples from all threads
+- **Individual threads** - Analyze a specific thread, e.g. "TID 12345 (worker-thread)"
+
+This is useful for identifying which threads are consuming the most resources or analyzing thread-specific performance characteristics.
+
+### Using Other Profilers
 
 If you are using another profiler, you will need to generate a `perf.log` file that stores data in the flamegraph format, i.e. as a list of `;`-separated stack traces with a count at the end in each line.
 For example:

--- a/doc/perfanno.txt
+++ b/doc/perfanno.txt
@@ -44,7 +44,7 @@ to the hottest callers of any piece of code or any function. See
 ==============================================================================
 INSTALLATION                                             *perfanno-installation*
 
-This plugin requires NeoVim 0.9 and was tested most recently with NeoVim 0.11
+This plugin requires NeoVim 0.10 and was tested most recently with NeoVim 0.11
 and perf 5.16.
 If you wish to load a call graph with stack traces, you may need a relatively
 recent version of perf.
@@ -123,7 +123,11 @@ configuration is given below.
             -- weirdlang = {
             --     "weirdfunc",
             -- }
-        }
+        },
+
+        -- Enable per-thread profiling for multi-threaded applications
+        -- When enabled, you can select which thread(s) to profile
+        thread_support = false,
     }
 
     local telescope = require("telescope")
@@ -207,6 +211,25 @@ also want to try:
 However, this requires that your program and all libraries have been compiled
 with `--fno-omit-frame-pointer` and you may find that the line numbers are
 slightly off. For more information, see `PERF(1)`.
+
+Multi-threaded Applications~
+
+If you're profiling multi-threaded applications and want to analyze per-thread
+performance, enable `thread_support` in your configuration:
+>
+    require("perfanno").setup({
+        thread_support = true,
+    })
+<
+When loading perf data from a multi-threaded program, you'll be prompted to
+select which thread(s) to profile:
+  - All threads (aggregated) - Default behavior, combines all threads
+  - Individual threads - Analyze a specific thread (e.g., "TID 12345 (worker)")
+
+This is useful for identifying which threads consume the most resources or for
+analyzing thread-specific performance characteristics.
+
+Other Profiling Tools~
 
 If you are using another profiling tool that is not perf, you need to generate
 a list of folded stacktraces. See |:PerfLoadFlameGraph| for more details.

--- a/lua/perfanno/config.lua
+++ b/lua/perfanno/config.lua
@@ -54,6 +54,12 @@ local defaults = {
     -- Overwrite the default behaviour of prompting for the path to the perf.data with a custom function that returns
     -- the path to a perf file as string.
     get_path_callback = nil,
+
+    -- Enable per-thread profiling support for multi-threaded applications.
+    -- When enabled and multiple threads are detected in perf.data, prompts user to select which thread(s) to profile.
+    -- Options: all threads (aggregated, default) or individual threads.
+    -- Disabled by default for backward compatibility.
+    thread_support = false,
 }
 
 local M = {}

--- a/lua/telescope/_extensions/perfanno.lua
+++ b/lua/telescope/_extensions/perfanno.lua
@@ -60,7 +60,12 @@ local function annotated_previewer(annotate_fn)
                 vim.api.nvim_buf_clear_namespace(bufnr, previewer_ns, 0, -1)
 
                 -- Get line length for range highlighting
-                local line_text = vim.api.nvim_buf_get_lines(bufnr, entry.lnum - 1, entry.lnum, false)[1] or ""
+                local line_text = vim.api.nvim_buf_get_lines(
+                    bufnr,
+                    entry.lnum - 1,
+                    entry.lnum,
+                    false
+                )[1] or ""
                 local line_len = #line_text
 
                 vim.api.nvim_buf_set_extmark(bufnr, previewer_ns, entry.lnum - 1, 0, {


### PR DESCRIPTION
## Summary

This PR adds some basic multi-thread support. Note that it is somewhat cumbersome to get the output all at once from perf, so I've chosen to go with a very simple approach where we check first which threads are available, and then just ask the user to chose either (a) all threads (b) a single thread. We can then re-use all the existing logic without much effort.

## Testing

Given the nature of this (relying on actual perf commands), I did some manual testing with a perf run with various threads, including one that renamed itself. The output looks reasonable.